### PR TITLE
Add optional banner config HTML support section

### DIFF
--- a/469-e/overview/sep-ui.html
+++ b/469-e/overview/sep-ui.html
@@ -657,11 +657,18 @@ following configuration property to the desired size in the coordinator’s
 <p>Add text to the <strong>Banner messaging</strong> text field to create a short message of 300
 characters or less. The banner message appears across the top of the login
 screen for logged out users.</p>
+<p><strong>Optional Configuration:</strong></p>
+<ul>
+  <li>You may choose to display the banner message at the <strong>top or bottom</strong> of the login screen depending on your custom UI implementation or CSS override. The default is top.</li>
+  <li>HTML support may allow for <strong>clickable hyperlinks</strong> in the banner. Example:</li>
+</ul>
+<pre><code>&lt;a href="https://your.link/here"&gt;Click here for support&lt;/a&gt;</code></pre>
+<p>Note: HTML rendering support may depend on your version or administrator-defined restrictions.</p>
 <p>The Starburst Enterprise web UI can be configured to allow more text by setting the following
 configuration property to the desired size in the coordinator’s
 <code class="docutils literal notranslate"><span class="pre">config.properties</span></code> file:</p>
 <div class="highlight-properties notranslate"><div class="highlight"><pre><span></span><span class="c1"># value in chars; default is 300</span>
-<span class="na">sep-ui.security.banner-text-max-size</span><span class="o">=</span><span class="s">300</span>
+<span class="na">sep-ui.security.banner-text-max-size</span><span class="o">=</span><span class="s">500</span>
 </pre></div>
 </div>
 </section>


### PR DESCRIPTION
Added a section describing how to optionally configure the banner message on the Starburst login screen. Includes support for positioning (top/bottom), HTML hyperlinks, and increasing character limit using `sep-ui.security.banner-text-max-size` in `config.properties`.
